### PR TITLE
Version 1.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,23 +7,13 @@ For starters, be sure to import the pyrad library:
 To create a plot, the first object that is needed is a Layer object. A layer has attributes of 
 (depth in cm, temperature in Kelvin, pressure in mBars, minimum window range in wavenumber cm-1, 
 maximum window range in wavenumber cm-1)
-# var_name = pyrad.Layer(10, 296, 1013.25, 600, 700
-Next, define the molecules that make up the layer. This can be done in 2 ways. Either method will
-require the same attributes to be defined, which are a (text name, HITRAN molecule ID - see table below,
-molecular weight, concentration). Concentration can be defined using ppm=, ppb=, percentage=, or concentration=,
-the app will adjust accordingly. You will get a warning if total concentrations exceed 1. First method for adding
-molecules, add them one at a time directly to the layer using .addMolecule. It's also a good idea if you want to 
-change properties of the molecules to set this equal to a molecule variable name. For ease, use the same variable
-name as description:
-####    UPDATE      ####
-ONLY USE THE TEXT NAME OF THE MOLECULE, NO NEED TO GIVE THE MOLECULE ID ANYMORE
+# var_name = pyrad.Layer(10, 296, 1013.25, 600, 700)
+Next, define the molecules that make up the layer. To do so, use layer.addMolecule(text name or molecule ID, 
+concentration, isotopeDepth) 
+
 # co2 = your_layer_name_here.addMolecule('co2', 44, ppm=350)
 # h2o = your_layer_name_here.addMolecule('h2o', 18, percentage=.4)
-The second method involves defining the molecules individually, then adding them to the layer using 
-.addMolecules (note the 's' on the end)
-# co2 = pyrad.Molecule('co2', 2, 44, ppm=350)
-# h2o = pyrad.Molecule('h2o, 1, 18, concentration=.004)
-# layer.addMolecules(co2, h2o)
+
 With the layer properties and composition defined, choose what to plot:
 # pyrad.plot(object, plotchoice)
 
@@ -32,19 +22,22 @@ Object can be layer, or just an individual molecule. plotchoice can be:
 'absorption coefficient'
 'absorbance'
 'cross section'
-Personal favorite add-on is to set individualColors=True in the plot command. This will plot up to
-6 molecules individually by color as well as the total in white. There is also a choice to set 
-fill=False if you prefer to see just the outline.
+'emissivity'
+
+Personal favorite add-on is to set individualColors=True in the plot command. This will plot the base object in white
+and up to 6 of the objects that make it up in individual colors. Example, define co2 to have an isotope depth of 3,
+plotting the transmittance will show each isotope in it's own color with the total transmittance in white. There is 
+also a choice to set fill=False if you prefer to see just the outline.
 Questions or bugs, email brad.schrag@gmail.com
 """
 
-layer = pyrad.Layer(10, 300, 101.325, 640, 670)
-co2 = pyrad.Molecule('co2', 44, ppm=400)
-h2o = pyrad.Molecule('h2o', 18, percentage=.4)
-ozone = pyrad.Molecule('o3', 48, ppb=10)
+layer = pyrad.Layer(10, 300, 1013.25, 635, 640)
+co2 = layer.addMolecule('co2', ppm=400, isotopeDepth=3)
+h2o = layer.addMolecule('h2o', percentage=.4)
+ozone = layer.addMolecule('o3', ppb=10)
 
-layer.addMolecules(co2, h2o, ozone)
-pyrad.plot(co2, 'transmittance', individualColors=True)
+layer.createCrossSection()
+pyrad.plot(layer, 'transmittance', individualColors=True)
 
 """
 MOLECULE_ID = {'h2o': 1, 'co2': 2, 'o3': 3, 'n2o': 4, 'co': 5,

--- a/pyradUtilities.py
+++ b/pyradUtilities.py
@@ -4,13 +4,32 @@ import urllib.request as urlrequest
 cwd = os.getcwd()
 dataDir = '%s/data' % cwd
 curvesDir = '%s/curves' % dataDir
+molParamsFile = '%s/molparams.txt' % dataDir
 
 
 def setupDir():
-    if not os.path.isdir(dataDir):
-        os.makedirs(dataDir)
-    if not os.path.isdir(curvesDir):
-        os.makedirs(curvesDir)
+    print('Verifying data stucture...', end='', flush=True)
+    directoryList = [dataDir, curvesDir]
+    fileList = []
+    directoryCheck = True
+    fileCheck = True
+    for moleculeID in HITRAN_GLOBAL_ISO:
+        for localIsoID in HITRAN_GLOBAL_ISO[moleculeID]:
+            globalIsoPath = '%s/%s' % (dataDir, HITRAN_GLOBAL_ISO[moleculeID][localIsoID])
+            isotopeFilePath = '%s/param.pyr' % globalIsoPath
+            directoryList.append(globalIsoPath)
+            fileList.append(isotopeFilePath)
+    for directory in directoryList:
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
+    print('directories checked...', end='', flush=True)
+    for file in fileList:
+        if not os.path.isfile(file):
+            if not os.path.isfile(molParamsFile):
+                downloadMolParam()
+            getMolParamsFromHitranFile()
+    print('files checked.')
+    return directoryCheck and fileCheck
 
 
 def openReturnLines(fullPath):
@@ -20,6 +39,18 @@ def openReturnLines(fullPath):
     lineList = openFile.readlines()
     openFile.close()
     return lineList
+
+
+def writeDictListToFile(dictionary, fullPath):
+    openFile = open(fullPath, 'w')
+    for key in dictionary:
+        text = '%s,%s\n' % (key, ','.join(str(item) for item in dictionary[key]))
+        openFile.write(text)
+    openFile.close()
+
+
+def writeListToFile():
+    pass
 
 
 def getCurves(curveType):
@@ -33,6 +64,37 @@ def getCurves(curveType):
             key = cells.pop(0)
             curveDict[key] = cells
     return curveDict
+
+
+def getMolParamsFromHitranFile():
+    rows = openReturnLines(molParamsFile)
+    isotopeInfo = {}
+    i = 0
+    while i < len(rows) -1:
+        cells = rows[i].split()
+        while cells[0].lower() in MOLECULE_ID and i < len(rows) - 1:
+            moleculeShortName = cells[0].lower()
+            moleculeID = int(cells[1].replace(')', '').replace('(', ''))
+            i += 1
+            isotopeNumber = 1
+            cells = rows[i].split()
+            while cells[0].lower() not in MOLECULE_ID:
+                IsoN = int(cells[0])
+                abundance = float(cells[1])
+                q296 = float(cells[2])
+                gj = int(cells[3])
+                molMass = float(cells[4])
+                globalID = HITRAN_GLOBAL_ISO[moleculeID][isotopeNumber]
+                infoList = [moleculeShortName, moleculeID, IsoN, abundance, q296, gj, molMass]
+                isotopeInfo[globalID] = infoList
+                writeDictListToFile({globalID: isotopeInfo[globalID]},'%s/%s/params.pyr' % (dataDir, globalID))
+                isotopeNumber += 1
+                i += 1
+                if i == len(rows):
+                    break
+                cells = rows[i].split()
+        i += 1
+    return isotopeInfo
 
 
 def gatherData(globalIsoId, rangeMin, rangeMax):
@@ -63,6 +125,28 @@ def getQData(isotope):
     return readQFile(isotope)
 
 
+def downloadMolParam():
+    print('Missing molecule parameters file. Downloading from http://hitran.org')
+    url = 'http://hitran.org/media/molparam.txt'
+    try:
+        request = urlrequest.urlopen(url)
+    except urlrequest.HTTPError:
+        print('Can not retrieve file at %s. Exiting.' % url)
+        return False
+    except urlrequest.URLError:
+        print('Can not connect. Exiting')
+        return False
+    chunkSize = 1024 * 64
+    openFile = open(molParamsFile, 'w')
+    while True:
+        chunk = request.read(chunkSize)
+        if not chunk:
+            print('Molecule parameters successfully downloaded.')
+            break
+        openFile.write(chunk.decode('utf-8'))
+    openFile.close()
+
+
 def downloadQData(isotope):
     url = 'http://hitran.org/data/Q/q%s.txt' % str(isotope)
     path = cwd + '/data/%s/q%s.txt' % (isotope, isotope)
@@ -70,26 +154,12 @@ def downloadQData(isotope):
     print('Downloading Q table from %s' % url)
     openFile = open(path, 'w')
     chunkSize = 1024 * 64
-
     while True:
         chunk = request.read(chunkSize)
         if not chunk:
             break
         openFile.write(chunk.decode('utf-8'))
     openFile.close()
-
-
-def readQFile(isotope):
-    path = cwd + '/data/%s/q%s.txt' % (isotope, isotope)
-    if not os.path.isfile:
-        downloadQData(isotope)
-    openFile = open(path, 'r')
-    rows = openFile.readlines()
-    qDict = {}
-    for row in rows:
-        cell = row.split()
-        qDict[int(cell[0])] = float(cell[1])
-    return qDict
 
 
 def downloadHitran(path, globalID, waveMin, waveMax):
@@ -168,7 +238,40 @@ def readHitranOnlineFile(path, waveMin, waveMax):
     return lineListDict
 
 
-GREETING = "***********************           PyRad ver 1           ***********************\n" \
+def readQFile(isotope):
+    path = cwd + '/data/%s/q%s.txt' % (isotope, isotope)
+    if not os.path.isfile:
+        downloadQData(isotope)
+    openFile = open(path, 'r')
+    rows = openFile.readlines()
+    qDict = {}
+    for row in rows:
+        cell = row.split()
+        qDict[int(cell[0])] = float(cell[1])
+    return qDict
+
+
+def readMolParams(globalIso):
+    filePath = '%s/%s/params.pyr' % (dataDir, globalIso)
+    params = openReturnLines(filePath)
+    row = params[0]
+    cells = row.split(',')
+    globalIso = int(cells[0])
+    shortName = cells[1]
+    moleculeNum = int(cells[2])
+    isoN = int(cells[3])
+    abundance = float(cells[4])
+    q296 = float(cells[5])
+    gj = int(cells[6])
+    molMass = float(cells[7])
+    return [globalIso, shortName, moleculeNum, isoN, abundance, q296, gj, molMass]
+
+
+VERSION = '1.1'
+titleLine = "***********************              PyRad              ***********************"
+messageGap = int((len(titleLine) - len(VERSION) - 1) / 2)
+GREETING = "%s\n" \
+           "%sv%s%s\n" \
            "An open-source, amateur attempt at a radiative transfer model for an atmosphere\n\n" \
            "\tAll line lists are downloaded from HITRAN\n" \
            "\tAll information for calculation of lineshapes comes \n" \
@@ -176,6 +279,150 @@ GREETING = "***********************           PyRad ver 1           ************
            "\tFor a more complete option, check out HAPI from HITRAN.\n" \
            "\tThanks to those you have made the information available \n" \
            "\tand so easily accessible.\n\n" \
-           "*******************************************************************************"
+           "*******************************************************************************" \
+           % (titleLine, ' ' * messageGap, VERSION, ' ' * (len(titleLine) - messageGap))
+
+HITRAN_GLOBAL_ISO = {1: {1: 1,
+                         2: 2,
+                         3: 3,
+                         4: 4,
+                         5: 5,
+                         6: 6,
+                         7: 129},
+                     2: {1: 7,
+                         2: 8,
+                         3: 9,
+                         4: 10,
+                         5: 11,
+                         6: 12,
+                         7: 13,
+                         8: 14,
+                         9: 121,
+                         10: 15,
+                         11: 120,
+                         12: 122},
+                     3: {1: 16,
+                         2: 17,
+                         3: 18,
+                         4: 19,
+                         5: 20},
+                     4: {1: 21,
+                         2: 22,
+                         3: 23,
+                         4: 24,
+                         5: 25, },
+                     5: {1: 26,
+                         2: 27,
+                         3: 28,
+                         4: 29,
+                         5: 30,
+                         6: 31},
+                     6: {1: 32,
+                         2: 33,
+                         3: 34,
+                         4: 35},
+                     7: {1: 36,
+                         2: 37,
+                         3: 38},
+                     8: {1: 39,
+                         2: 40,
+                         3: 41},
+                     9: {1: 42,
+                         2: 43},
+                     10: {1: 44},
+                     11: {1: 45,
+                          2: 46},
+                     12: {1: 47,
+                          2: 117},
+                     13: {1: 48,
+                          2: 49,
+                          3: 50},
+                     14: {1: 51,
+                          2: 110},
+                     15: {1: 52,
+                          2: 53,
+                          3: 107,
+                          4: 108},
+                     16: {1: 19,
+                          2: 11,
+                          3: 111,
+                          4: 112},
+                     17: {1: 56,
+                          2: 113},
+                     18: {1: 57,
+                          2: 58},
+                     19: {1: 59,
+                          2: 60,
+                          3: 61,
+                          4: 62,
+                          5: 63},
+                     20: {1: 64,
+                          2: 65,
+                          3: 66},
+                     21: {1: 67,
+                          2: 68},
+                     22: {1: 69,
+                          2: 118},
+                     23: {1: 70,
+                          2: 71,
+                          3: 72},
+                     24: {1: 73,
+                          2: 74},
+                     25: {1: 75},
+                     26: {1: 76,
+                          2: 77,
+                          3: 105},
+                     27: {1: 78,
+                          2: 106},
+                     28: {1: 79},
+                     29: {1: 80,
+                          2: 119},
+                     30: {1: 126},
+                     31: {1: 81,
+                          2: 82,
+                          3: 83},
+                     32: {1: 84},
+                     33: {1: 85},
+                     34: {1: 86},
+                     35: {1: 127,
+                          2: 128},
+                     36: {1: 87},
+                     37: {1: 88,
+                          2: 89},
+                     38: {1: 90,
+                          2: 91},
+                     39: {1: 92},
+                     40: {1: 93,
+                          2: 94},
+                     41: {1: 95},
+                     42: {1: 96},
+                     43: {1: 116},
+                     44: {1: 109},
+                     45: {1: 103,
+                          2: 115},
+                     46: {1: 97,
+                          2: 98,
+                          3: 99,
+                          4: 100},
+                     47: {1: 114},
+                     48: {1: 123},
+                     49: {1: 124,
+                          2: 125}}
+
+
+MOLECULE_ID = {'h2o': 1, 'co2': 2, 'o3': 3, 'n2o': 4, 'co': 5,
+               'ch4': 6, 'o2': 7, 'no': 8, 'so2': 9,
+               'no2': 10, 'nh3': 11, 'hno3': 12, 'oh': 13,
+               'hf': 14, 'hcl': 15, 'hbr': 16, 'hi': 17,
+               'clo': 18, 'ocs': 19, 'h2co': 20, 'hocl': 21,
+               'n2': 22, 'hcn': 23, 'ch3cl': 24, 'h2o2': 25,
+               'c2h2': 26, 'c2h6': 27, 'ph3': 28, 'cof2': 29,
+               'sf6': 30, 'h2s': 31, 'hcooh': 32, 'ho2': 33,
+               'o': 34, 'clono2': 35, 'no+': 36, 'hobr': 37,
+               'c2h4': 38, 'ch3oh': 39, 'ch3br': 40, 'ch3cn': 41,
+               'cf4': 42, 'c4h2': 43, 'hc3n': 44, 'h2': 45,
+               'cs': 46, 'so3': 47, 'c2n2': 48, 'cocl2': 49}
+
+
 print(GREETING)
 setupDir()


### PR DESCRIPTION
- Lots of refactoring, not too many additions for options
- Created class structures for lines and isotopes
- added emissivity to plot choice
- deprecated layer.addMolecules. Only way to add molecules now is through layer.addMolecule. This works well to setup up the molecule parent layer. This helps clean up the code and readability by allowing calls to molecule.T or isotope.depth, which makes a call to the parent layer for the property.