### PR TITLE
bug fix

### DIFF
--- a/pyradUtilities.py
+++ b/pyradUtilities.py
@@ -72,6 +72,8 @@ def getMolParamsFromHitranFile():
     haveMolecule = False
     for row in rows:
         cells = row.split()
+        if cells == []:
+            break
         if cells[0].lower() in MOLECULE_ID:
             localIso = 0
             haveMolecule = True

--- a/pyradUtilities.py
+++ b/pyradUtilities.py
@@ -69,31 +69,25 @@ def getCurves(curveType):
 def getMolParamsFromHitranFile():
     rows = openReturnLines(molParamsFile)
     isotopeInfo = {}
-    i = 0
-    while i < len(rows) -1:
-        cells = rows[i].split()
-        while cells[0].lower() in MOLECULE_ID and i < len(rows) - 1:
+    haveMolecule = False
+    for row in rows:
+        cells = row.split()
+        if cells[0].lower() in MOLECULE_ID:
+            localIso = 0
+            haveMolecule = True
             moleculeShortName = cells[0].lower()
             moleculeID = int(cells[1].replace(')', '').replace('(', ''))
-            i += 1
-            isotopeNumber = 1
-            cells = rows[i].split()
-            while cells[0].lower() not in MOLECULE_ID:
-                IsoN = int(cells[0])
-                abundance = float(cells[1])
-                q296 = float(cells[2])
-                gj = int(cells[3])
-                molMass = float(cells[4])
-                globalID = HITRAN_GLOBAL_ISO[moleculeID][isotopeNumber]
-                infoList = [moleculeShortName, moleculeID, IsoN, abundance, q296, gj, molMass]
-                isotopeInfo[globalID] = infoList
-                writeDictListToFile({globalID: isotopeInfo[globalID]},'%s/%s/params.pyr' % (dataDir, globalID))
-                isotopeNumber += 1
-                i += 1
-                if i == len(rows):
-                    break
-                cells = rows[i].split()
-        i += 1
+        elif haveMolecule:
+            localIso += 1
+            IsoN = int(cells[0])
+            abundance = float(cells[1])
+            q296 = float(cells[2])
+            gj = int(cells[3])
+            molMass = float(cells[4])
+            globalID = HITRAN_GLOBAL_ISO[moleculeID][localIso]
+            infoList = [moleculeShortName, moleculeID, IsoN, abundance, q296, gj, molMass]
+            isotopeInfo[globalID] = infoList
+            writeDictListToFile({globalID: isotopeInfo[globalID]}, '%s/%s/params.pyr' % (dataDir, globalID))
     return isotopeInfo
 
 

--- a/pyradUtilities.py
+++ b/pyradUtilities.py
@@ -37,6 +37,8 @@ def openReturnLines(fullPath):
         return []
     openFile = open(fullPath)
     lineList = openFile.readlines()
+    if lineList[-1] == []:
+        lineList.pop()
     openFile.close()
     return lineList
 
@@ -72,8 +74,6 @@ def getMolParamsFromHitranFile():
     haveMolecule = False
     for row in rows:
         cells = row.split()
-        if cells == []:
-            break
         if cells[0].lower() in MOLECULE_ID:
             localIso = 0
             haveMolecule = True


### PR DESCRIPTION
An issue has shown up in reading line files on Windows machines. file.readlines() seems to return an empty array for the end of file, rather than returning nothing. Updated openFileReadLines to crop off the last item if it's an empty list, ie [ ]